### PR TITLE
chore: remove unused if_tag after reverting IF CM filename

### DIFF
--- a/scripts/run_baselines.py
+++ b/scripts/run_baselines.py
@@ -259,11 +259,6 @@ def main():
         f"bootstrap={if_params['bootstrap']}, "
         f"n_jobs={if_params['n_jobs']})"
     )
-    if_tag = (
-        f"ne{if_params['n_estimators']}_"
-        f"ms{str(if_params['max_samples']).replace('%','p')}_"
-        f"nj{if_params['n_jobs']}"
-    )
 
     m = compute_metrics(y_test, y_pred, y_score)
     write_metrics_csv(


### PR DESCRIPTION
Removes leftover if_tag variable now that IF CM filename is static again. No functional changes.